### PR TITLE
Bunyan dependency change and logging fix

### DIFF
--- a/lib/trap_listener.js
+++ b/lib/trap_listener.js
@@ -103,8 +103,7 @@ TrapListener.prototype.bind = function bind(arg) {
 	this._connections.push(conn);
 
 	conn.bind(arg.port, arg.addr);
-	this._log.info('Bound to ' + conn.address().address + ':' +
-	    conn.address().port);
+	this._log.info('Bound to ' + arg.addr + ':' + arg.port);
 };
 
 TrapListener.prototype.close = function close() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"dependencies": {
 		"jison": "0.3",
 		"asn1": "~0.1",
-		"bunyan": "~0.18",
+		"bunyan": "0.18.0",
 		"dtrace-provider": "~0.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Getting errors with the serializers and Bunyan 0.18.3 in my environment; fixed the dependency on 0.18.0 which works fine.

Also got "Error: getsockname EINVAL" when trying to access conn.address()... Anyways, figured it's safe to assume it'll be the host/port we were trying for.
