### PR TITLE
bogus Trap constant and recursive enterprise getter

### DIFF
--- a/lib/protocol/pdu.js
+++ b/lib/protocol/pdu.js
@@ -255,7 +255,7 @@ SnmpTrapV1PDU(arg)
 		return (undefined);
 	});
 	this.__defineSetter__('enterprise',
-	    _set_bind(self, 'enterprise', 'string', 'ObjectIdentifier'));
+	    _set_bind(self, '_enterprise', 'string', 'ObjectIdentifier'));
 	this.__defineGetter__('agent_addr', function () {
 		if (self._agent_addr)
 			return (self._agent_addr.value);
@@ -300,7 +300,7 @@ util.inherits(SnmpTrapV1PDU, SnmpPDU);
 
 SnmpTrapV1PDU.prototype.encode = function (writer) {
 	var i;
-
+	
 	writer.startSequence(ASN1.Context | ASN1.Constructor | this._op);
 	this._enterprise.encode(writer);
 	this._agent_addr.encode(writer);
@@ -322,9 +322,9 @@ createPDU(arg)
 		throw new TypeError('arg (object) is required');
 	if (typeof (arg.op) !== 'number')
 		throw new TypeError('arg.op (number) is reguired');
-
+	
 	switch (arg.op) {
-	case SnmpPDU.Trap:
+	case OPS.Trap:
 		return (new SnmpTrapV1PDU(arg));
 	default:
 		return (new SnmpStdPDU(arg));


### PR DESCRIPTION
During encoding, the op field of the pdu arg was being compared against the undefined value "SnmpPdu.Trap." This precluded the creation of SnmpTrapV1PDU items and correct encoding of v1 specific trap fields. The comparison is now against the [deprecated] "OPS.Trap" field.

Also, the enterprise field of the SnmpTrapV1PDU had a self-recursive setter. That is, the setter for pdu['enterprise'] ended with an assignment to pdu['enterprise']. This has been changed to assign to '_enterprise', as returned by the getter.

(As an aside... this is my first use of Git, Github, and of course the pull request feature. Let me know if I've done something out of the ordinary.)
