### PR TITLE
fix trap_listener crash when call `close`

### DIFF
--- a/lib/trap_listener.js
+++ b/lib/trap_listener.js
@@ -116,8 +116,10 @@ TrapListener.prototype.bind = function bind(arg, cb) {
 };
 
 TrapListener.prototype.close = function close() {
+    var self = this;
+
 	this._connections.forEach(function (c) {
-		this._log.info('Shutting down endpoint ' + c.address().address +
+		self._log.info('Shutting down endpoint ' + c.address().address +
 		    ':' + c.address().port);
 		c.close();
 	});


### PR DESCRIPTION
This problem is occurring by variable scope.
