### PR TITLE
pad octet array to the left to avoid weirdness with values >= 2^23

### DIFF
--- a/lib/protocol/uint64_t.js
+++ b/lib/protocol/uint64_t.js
@@ -350,6 +350,8 @@ uint64_t.prototype.toOctets = function uint64_t_toOctets() {
 		v.hi >>>= 8;
 	}
 
+	while (a.length<8) a.unshift(0);
+
 	return (a);
 };
 


### PR DESCRIPTION
Noticed there was some weirdness with snmpwalk when I tried to set Counter64 to values greater than or equal to 8388608 (aka 8mb aka 2^23):

.1.3.6.1.2.1.31.1.1.1.6.1 = Counter64: 18374967954639945728
.1.3.6.1.2.1.31.1.1.1.6.2 = Counter64: 8388607

This seems to be caused by the uint64_t.prototype.toOctets method not padding the array:

toOctets: hi:0, lo: 8388608 -> 128,0,0
toOctets: hi:0, lo: 8388607 -> 127,255,255

Once I padded the array by prepending 0's, things look better:

.1.3.6.1.2.1.31.1.1.1.6.1 = Counter64: 8388608
.1.3.6.1.2.1.31.1.1.1.6.2 = Counter64: 8388607

The change is very small: while (a.length<8) a.unshift(0);
